### PR TITLE
page request constructor name changed

### DIFF
--- a/src/core/proxy.js
+++ b/src/core/proxy.js
@@ -41,7 +41,7 @@ const useProxy = async (target, proxy) => {
         }
     };
     // Proxy per request
-    if (target.constructor.name === "Request") {
+    if (target.constructor.name.indexOf("Request")!=-1) {
         if (type(proxy) == "object") {
             target = setOverrides(target, proxy);
             proxy = proxy.proxy;


### PR DESCRIPTION
puppeteer page constructor on request based interception is changed to HTTPRequest instead of just Request. To support latest version the changes are made for forwarding request based network calls.