### PR TITLE
Fixed infinite redirects when trying to GET an Instagram profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm i puppeteer-page-proxy
 - `proxy` <[string](https://developer.mozilla.org/en-US/docs/Glossary/String)|[object](https://developer.mozilla.org/en-US/docs/Glossary/Object)> Proxy to use in the current page.
   * Begins with a protocol (e.g. http://, https://, socks://)
   * In the case of [proxy per request](https://github.com/Cuadrix/puppeteer-page-proxy#proxy-per-request), this can be an object with optional properties for overriding requests:\
-`url`, `method`, `postData`, `headers`, `ignoreInvalidCookies`\
+`url`, `method`, `postData`, `headers`\
 See [httpRequest.continue](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#httprequestcontinueoverrides) for more info about the above properties.
   
 #### PageProxy.lookup(page[, lookupService, isJSON, timeout])

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm i puppeteer-page-proxy
 - `proxy` <[string](https://developer.mozilla.org/en-US/docs/Glossary/String)|[object](https://developer.mozilla.org/en-US/docs/Glossary/Object)> Proxy to use in the current page.
   * Begins with a protocol (e.g. http://, https://, socks://)
   * In the case of [proxy per request](https://github.com/Cuadrix/puppeteer-page-proxy#proxy-per-request), this can be an object with optional properties for overriding requests:\
-`url`, `method`, `postData`, `headers`\
+`url`, `method`, `postData`, `headers`, `ignoreInvalidCookies`\
 See [httpRequest.continue](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#httprequestcontinueoverrides) for more info about the above properties.
   
 #### PageProxy.lookup(page[, lookupService, isJSON, timeout])

--- a/src/core/proxy.js
+++ b/src/core/proxy.js
@@ -19,7 +19,11 @@ const requestHandler = async (request, proxy, overrides = {}) => {
         agent: setAgent(proxy),
         responseType: "buffer",
         maxRedirects: 15,
-        throwHttpErrors: false
+        throwHttpErrors: false,
+        ignoreInvalidCookies:
+            typeof overrides.ignoreInvalidCookies === "undefined"
+                ? false
+                : overrides.ignoreInvalidCookies
     };
     try {
         const response = await got(overrides.url || request.url(), options);

--- a/src/core/proxy.js
+++ b/src/core/proxy.js
@@ -35,7 +35,10 @@ const requestHandler = async (request, proxy, overrides = {}) => {
             headers: response.headers,
             body: response.body
         });
-    } catch(error) {await request.abort()}
+    } catch (error) {
+        console.error(error)
+        await request.abort();
+    }
 };
 
 // For reassigning proxy of page

--- a/src/core/proxy.js
+++ b/src/core/proxy.js
@@ -40,8 +40,8 @@ const requestHandler = async (request, proxy, overrides = {}) => {
             body: response.body
         });
     } catch (error) {
-        console.error(error)
         await request.abort();
+        throw error;
     }
 };
 

--- a/src/core/proxy.js
+++ b/src/core/proxy.js
@@ -20,10 +20,7 @@ const requestHandler = async (request, proxy, overrides = {}) => {
         responseType: "buffer",
         maxRedirects: 15,
         throwHttpErrors: false,
-        ignoreInvalidCookies:
-            typeof overrides.ignoreInvalidCookies === "undefined"
-                ? false
-                : overrides.ignoreInvalidCookies,
+        ignoreInvalidCookies: true,
         followRedirect: false
     };
     try {
@@ -42,7 +39,6 @@ const requestHandler = async (request, proxy, overrides = {}) => {
         });
     } catch (error) {
         await request.abort();
-        throw error;
     }
 };
 

--- a/src/core/proxy.js
+++ b/src/core/proxy.js
@@ -23,7 +23,8 @@ const requestHandler = async (request, proxy, overrides = {}) => {
         ignoreInvalidCookies:
             typeof overrides.ignoreInvalidCookies === "undefined"
                 ? false
-                : overrides.ignoreInvalidCookies
+                : overrides.ignoreInvalidCookies,
+        followRedirect: false
     };
     try {
         const response = await got(overrides.url || request.url(), options);


### PR DESCRIPTION
Closes #32 

Fixed bugs:
- Silent failure when there was an invalid host in the cookies set by the server
- Page URL not updating in Puppeteer when there was a server-side redirect (via location header)

Improvements:
- Added an optional `ignoreInvalidCookies` option to make this change backwards-compatible
- Added a `.gitignore` file so `/node_modules` cannot be committed to the repo
- Added a `throw error;` so that useProxy does not fail silently when there is an error. This error can be caught by the consumer if they want to ignore it or handle it. This is NOT a backwards-compatible change.