### PR TITLE
TypeError [ERR_INVALID_URL]: Invalid URL

### DIFF
--- a/src/lib/cookies.js
+++ b/src/lib/cookies.js
@@ -65,7 +65,7 @@ class CookieHandler extends CDP {
     constructor(request) {
         super(request._client);
         this.url = request.isNavigationRequest() ? request.url() : request.frame().url();
-        this.domain = new URL(this.url).hostname;
+        this.domain = (this.url) ? new URL(this.url).hostname : '';
     }
     // Parse an array of raw cookies to an array of cookie objects
     parseCookies(rawCookies) {


### PR DESCRIPTION
Workaround to this issue: https://github.com/Cuadrix/puppeteer-page-proxy/issues/48