### PR TITLE
Update proxy.js

### DIFF
--- a/src/core/proxy.js
+++ b/src/core/proxy.js
@@ -38,6 +38,9 @@ const requestHandler = async (request, proxy, overrides = {}) => {
             body: response.body
         });
     } catch (error) {
+        //If the request is being handled by other handlers then do not abort
+        // Related to Issues #89
+        if (request.isInterceptResolutionHandled()) return;
         await request.abort();
     }
 };


### PR DESCRIPTION
If puppeteer is used with other plugins the it gives an error Request Already Handled. This solution will check if the request is handled by some other handler or not if handled then no abort. 
It is related to an open issue #89 and closed issues #71 #46 