### PR TITLE
catch CookieHandler.getCookies error

### DIFF
--- a/src/core/proxy.js
+++ b/src/core/proxy.js
@@ -10,20 +10,20 @@ const requestHandler = async (request, proxy, overrides = {}) => {
         request.continue(); return;
     }
     const cookieHandler = new CookieHandler(request);
-    // Request options for GOT accounting for overrides
-    const options = {
-        cookieJar: await cookieHandler.getCookies(),
-        method: overrides.method || request.method(),
-        body: overrides.postData || request.postData(),
-        headers: overrides.headers || setHeaders(request),
-        agent: setAgent(proxy),
-        responseType: "buffer",
-        maxRedirects: 15,
-        throwHttpErrors: false,
-        ignoreInvalidCookies: true,
-        followRedirect: false
-    };
     try {
+        // Request options for GOT accounting for overrides
+        const options = {
+            cookieJar: await cookieHandler.getCookies(),
+            method: overrides.method || request.method(),
+            body: overrides.postData || request.postData(),
+            headers: overrides.headers || setHeaders(request),
+            agent: setAgent(proxy),
+            responseType: "buffer",
+            maxRedirects: 15,
+            throwHttpErrors: false,
+            ignoreInvalidCookies: true,
+            followRedirect: false
+        };
         const response = await got(overrides.url || request.url(), options);
         // Set cookies manually because "set-cookie" doesn't set all cookies (?)
         // Perhaps related to https://github.com/puppeteer/puppeteer/issues/5364


### PR DESCRIPTION
sometimes TargetClosed error occurred when get cookies and it crashed app